### PR TITLE
CLI action to List/Get Schedulers

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,19 @@
+name: Lint
+on: pull_request
+jobs:
+  golangci:
+    name: Run linters
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Restore cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Run linters
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          args: -E goimports --timeout 5m0s

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,23 @@
+name: Test
+on: push
+jobs:
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.16.3'
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+    - name: Run tests
+      run: |
+        make test
+    - name: Upload coverage to Codecov
+      run: bash <(curl -s https://codecov.io/bash) -s _build

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ bin
 # VS Code IDE
 .vscode
 __debug_bin
+.editorconfig

--- a/cmd/create/create_scheduler.go
+++ b/cmd/create/create_scheduler.go
@@ -42,7 +42,7 @@ var createSchedulerCmd = &cobra.Command{
 	Long:    "Uses a file (argument) to create a new scheduler on Maestro.",
 	Args:    validateArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client, config, err := getClientAndConfig()
+		client, config, err := common.GetClientAndConfig()
 		if err != nil {
 			return err
 		}
@@ -117,16 +117,4 @@ func (cs *CreateScheduler) run(_ *cobra.Command, args []string) error {
 
 		logger.Info("Successfully created scheduler: " + request.Name)
 	}
-}
-
-func getClientAndConfig() (interfaces.Client, *extensions.Config, error) {
-
-	config, err := common.GetConfig()
-	if err != nil {
-		return nil, nil, fmt.Errorf("error getting client config: %w", err)
-	}
-
-	client := common.GetClient(config)
-
-	return client, config, nil
 }

--- a/cmd/create/create_scheduler_test.go
+++ b/cmd/create/create_scheduler_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/topfreegames/maestro-cli/mocks"
 )
 
-func TestCreateOperation(t *testing.T) {
+func TestCreateSchedulerAction(t *testing.T) {
 	dirPath, _ := os.Getwd()
 	config := &extensions.Config{
 		ServerURL: "http://localhost:8080",
@@ -50,7 +50,7 @@ func TestCreateOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		client := mocks.NewMockClient(mockCtrl)
-		client.EXPECT().Post("http://localhost:8080/schedulers", gomock.Any()).Return([]byte(""), 200, nil)
+		client.EXPECT().Post(config.ServerURL+"/schedulers", gomock.Any()).Return([]byte(""), 200, nil)
 
 		err := NewCreateScheduler(client, config).run(nil, []string{dirPath + "/fixtures/scheduler-config.yaml"})
 
@@ -62,7 +62,7 @@ func TestCreateOperation(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		client := mocks.NewMockClient(mockCtrl)
-		client.EXPECT().Post("http://localhost:8080/schedulers", gomock.Any()).Return([]byte(""), 404, nil)
+		client.EXPECT().Post(config.ServerURL+"/schedulers", gomock.Any()).Return([]byte(""), 404, nil)
 
 		err := NewCreateScheduler(client, config).run(nil, []string{dirPath + "/fixtures/scheduler-config.yaml"})
 

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -1,0 +1,22 @@
+// maestro-cli
+// https://github.com/topfreegames/maestro-cli
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get a resource",
+	Long:  `Get a resource, to know more type maestro-cli list --help.`,
+}
+
+func init() {
+	Cmd.AddCommand(getSchedulersCmd)
+}

--- a/cmd/get/get_schedulers.go
+++ b/cmd/get/get_schedulers.go
@@ -1,0 +1,98 @@
+// maestro-cli
+// https://github.com/topfreegames/maestro-cli
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package get
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/hako/durafmt"
+	"github.com/spf13/cobra"
+	"github.com/topfreegames/maestro-cli/common"
+	"github.com/topfreegames/maestro-cli/extensions"
+	"github.com/topfreegames/maestro-cli/interfaces"
+	v1 "github.com/topfreegames/maestro/pkg/api/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// getSchedulersCmd represents the list command
+var getSchedulersCmd = &cobra.Command{
+	Use:     "schedulers",
+	Short:   "Lists all schedulers",
+	Example: "maestro-cli get schedulers",
+	Long:    "Lists all schedulers of a given context.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, config, err := common.GetClientAndConfig()
+		if err != nil {
+			return err
+		}
+
+		return NewGetSchedulers(client, config).run(cmd, args)
+	},
+}
+
+type GetSchedulers struct {
+	client interfaces.Client
+	config *extensions.Config
+}
+
+func NewGetSchedulers(client interfaces.Client, config *extensions.Config) *GetSchedulers {
+	return &GetSchedulers{
+		client: client,
+		config: config,
+	}
+}
+
+func (cs *GetSchedulers) run(_ *cobra.Command, args []string) error {
+
+	logger := common.GetLogger()
+
+	logger.Debug("getting schedulers")
+
+	url := fmt.Sprintf("%s/schedulers", cs.config.ServerURL)
+	body, status, err := cs.client.Get(url, "")
+	if err != nil {
+		return fmt.Errorf("error on GET request: %w", err)
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("get schedulers response not ok, status: %s, body: %s", http.StatusText(status), string(body))
+	}
+
+	logger.Sugar().Debugf("success getting schedulers: %s", body)
+
+	var schedulers v1.ListSchedulersReply
+	err = protojson.Unmarshal(body, &schedulers)
+	if err != nil {
+		return fmt.Errorf("error parsing response body: %w", err)
+	}
+
+	cs.printSchedulersTable(schedulers.Schedulers)
+
+	return nil
+}
+
+func (cs *GetSchedulers) printSchedulersTable(schedulers []*v1.Scheduler) {
+	w := new(tabwriter.Writer)
+
+	// minwidth, tabwidth, padding, padchar, flags
+	w.Init(os.Stdout, 8, 8, 0, '\t', 0)
+
+	defer w.Flush()
+
+	format := "\n %s\t\t%s\t\t%s\t\t%s\t\t%s\t"
+	fmt.Fprintf(w, format, "GAME", "NAME", "STATE", "VERSION", "AGE")
+
+	for _, scheduler := range schedulers {
+		age := time.Since(scheduler.GetCreatedAt().AsTime())
+		prettyAge := durafmt.ParseShort(age).String()
+		fmt.Fprintf(w, format, scheduler.GetGame(), scheduler.GetName(), scheduler.GetState(), scheduler.GetVersion(), prettyAge)
+	}
+}

--- a/cmd/get/get_schedulers_test.go
+++ b/cmd/get/get_schedulers_test.go
@@ -1,0 +1,93 @@
+// maestro-cli
+// https://github.com/topfreegames/maestro-cli
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package get
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro-cli/extensions"
+	"github.com/topfreegames/maestro-cli/mocks"
+	v1 "github.com/topfreegames/maestro/pkg/api/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestGetSchedulersAction(t *testing.T) {
+	config := &extensions.Config{
+		ServerURL: "http://localhost:8080",
+	}
+
+	t.Run("with success", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		client := mocks.NewMockClient(mockCtrl)
+
+		schedulers := &v1.ListSchedulersReply{
+			Schedulers: []*v1.Scheduler{
+				{
+					Name:      "scheduler-test-1",
+					Game:      "the-game",
+					Version:   "1.0.0",
+					State:     "creating",
+					CreatedAt: timestamppb.Now(),
+				},
+			},
+		}
+
+		responseBody, _ := protojson.Marshal(schedulers)
+
+		client.EXPECT().Get(config.ServerURL+"/schedulers", gomock.Any()).Return(responseBody, 200, nil)
+
+		err := NewGetSchedulers(client, config).run(nil, []string{})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("fails when maestro API fails", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		client := mocks.NewMockClient(mockCtrl)
+		client.EXPECT().Get(config.ServerURL+"/schedulers", gomock.Any()).Return([]byte(""), 404, nil)
+
+		err := NewGetSchedulers(client, config).run(nil, []string{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "get schedulers response not ok, status: Not Found")
+	})
+
+	t.Run("fails when bad format response body", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		client := mocks.NewMockClient(mockCtrl)
+		client.EXPECT().Get(config.ServerURL+"/schedulers", gomock.Any()).Return([]byte(""), 200, nil)
+
+		err := NewGetSchedulers(client, config).run(nil, []string{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error parsing response body")
+	})
+
+	t.Run("fails when HTTP request faile", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		client := mocks.NewMockClient(mockCtrl)
+		client.EXPECT().Get(config.ServerURL+"/schedulers", gomock.Any()).Return([]byte(""), 0, errors.New("request failed"))
+
+		err := NewGetSchedulers(client, config).run(nil, []string{})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error on GET request: request failed")
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/topfreegames/maestro-cli/cmd/create"
+	"github.com/topfreegames/maestro-cli/cmd/get"
 	initPkg "github.com/topfreegames/maestro-cli/cmd/init"
 	"github.com/topfreegames/maestro-cli/cmd/version"
 	"github.com/topfreegames/maestro-cli/common"
@@ -42,4 +43,5 @@ func init() {
 	RootCmd.AddCommand(initPkg.Cmd)
 	RootCmd.AddCommand(create.Cmd)
 	RootCmd.AddCommand(version.Cmd)
+	RootCmd.AddCommand(get.Cmd)
 }

--- a/common/common.go
+++ b/common/common.go
@@ -9,8 +9,10 @@ package common
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/topfreegames/maestro-cli/extensions"
+	"github.com/topfreegames/maestro-cli/interfaces"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -19,6 +21,18 @@ import (
 var Verbose int
 
 var Context string
+
+func GetClientAndConfig() (interfaces.Client, *extensions.Config, error) {
+
+	config, err := GetConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting client config: %w", err)
+	}
+
+	client := GetClient(config)
+
+	return client, config, nil
+}
 
 func GetConfig() (*extensions.Config, error) {
 	filesystem := extensions.NewFileSystem()

--- a/common/common.go
+++ b/common/common.go
@@ -49,7 +49,7 @@ func GetClient(config *extensions.Config) *extensions.Client {
 }
 
 func GetLogger() *zap.Logger {
-	ll := zap.InfoLevel
+	var ll zapcore.Level
 	switch Verbose {
 	case 0:
 		ll = zap.ErrorLevel

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
+	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.16.1
 	github.com/onsi/gomega v1.11.0
@@ -16,7 +17,7 @@ require (
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0 // indirect
-	github.com/topfreegames/maestro v1.0.1-0.20210805195115-e0041d4d72e1
+	github.com/topfreegames/maestro v1.0.1-0.20210813144029-6e40b101c649 // indirect
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad // indirect
 	go.uber.org/zap v1.18.1
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,7 @@ github.com/golangci/revgrep v0.0.0-20210208091834-cd28932614b5 h1:c9Mqqrm/Clj5bi
 github.com/golangci/revgrep v0.0.0-20210208091834-cd28932614b5/go.mod h1:LK+zW4MpyytAWQRz0M4xnzEk50lSvqDQKfx304apFkY=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 h1:zwtduBRr5SSWhqsYNgcuWO2kFlpdOZbP0+yRjmvPGys=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg8RkN3rCIMLGE9CyYmU9pY2Jer6DgANEnZ/L/cQ=
+github.com/google/addlicense v0.0.0-20210729153508-ef04bb38a16b/go.mod h1:EMjYTRimagHs1FwlIqKyX3wAM0u3rA+McvlIIWmSamA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/certificate-transparency-go v1.0.21/go.mod h1:QeJfpSbVSfYc7RgB3gJFj9cbuQMMchQxrWXz8Ruopmg=
@@ -512,6 +513,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0 h1:ajue7SzQMywqRjg2fK7dcpc0QhFGpTR2plWfV4EZWR4=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0/go.mod h1:r1hZAcvfFXuYmcKyCJI9wlyOPIZUJl6FCB8Cpca/NLE=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
+github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b h1:wDUNC2eKiL35DbLvsDhiblTUXHxcOPwQSCzi7xpQUN4=
+github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -1000,6 +1003,10 @@ github.com/tommy-muehle/go-mnd/v2 v2.4.0 h1:1t0f8Uiaq+fqKteUR4N9Umr6E99R+lDnLnq7
 github.com/tommy-muehle/go-mnd/v2 v2.4.0/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/topfreegames/maestro v1.0.1-0.20210805195115-e0041d4d72e1 h1:G583mosraC+lpOnsPRStRomHVobDmVDu/d6VU5U/7gM=
 github.com/topfreegames/maestro v1.0.1-0.20210805195115-e0041d4d72e1/go.mod h1:1WqSHlgvmQP1O4LJ2O1p83idZchZVecuVQ9CiSgudCE=
+github.com/topfreegames/maestro v1.0.1-0.20210813131522-8bdc90076aa4 h1:kijLNiuw7DGepg1dC4cSttV/pCQ7/VD2OMGI7XrJfwk=
+github.com/topfreegames/maestro v1.0.1-0.20210813131522-8bdc90076aa4/go.mod h1:Wda84+HM9QXjFc5+6CDhGAuQxeGZMMcxvbiGW8kt3pg=
+github.com/topfreegames/maestro v1.0.1-0.20210813144029-6e40b101c649 h1:+TMMSiPgPwUsB/DsBNMFPLFLbJcEllCYljFvC8MB/U0=
+github.com/topfreegames/maestro v1.0.1-0.20210813144029-6e40b101c649/go.mod h1:Wda84+HM9QXjFc5+6CDhGAuQxeGZMMcxvbiGW8kt3pg=
 github.com/twitchtv/twirp v8.1.0+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/uber/prototool v1.10.0/go.mod h1:5YxuSf52pSRqPLknVoIrw0MkAaa5hj+clCfByH6Beos=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
This PR aims to add the action of list schedulers based on the current context server URL.

The action respects the following usage contract:

```
maestro get schedulers
 
Usage:
> maestro get schedulers
GAME	NAME		STATE		VERSION		AGE
zooba	zooba-greeen	creating	1.0.0		20 hours
zooba	zooba-greeen	creating	1.0.0		20 hours
```