### PR TITLE
Fix: create scheduler yaml parser

### DIFF
--- a/cmd/create/fixtures/scheduler-config.yaml
+++ b/cmd/create/fixtures/scheduler-config.yaml
@@ -1,4 +1,27 @@
 ---
 name: scheduler-name-1
 game: game-name
-version: 1.0.0
+termination_grace_period: 100
+portRange:
+  start: 1
+  end: 1000
+containers:
+- name: game-room-container-name
+  image: game-room-container-image
+  image_pull_policy: IfNotPresent
+  command:
+  - "./run"
+  environment:
+  - name: env-var-name
+    value: env-var-value
+  requests:
+    memory: 100mi
+    cpu: 100m
+  limits:
+    memory: 200mi
+    cpu: 200m
+  ports:
+  - name: container-port-name
+    protocol: https
+    port: 12345
+    host_port: 54321

--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,5 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1632,4 +1632,5 @@ rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=


### PR DESCRIPTION
## Description

This PR aims to fix the scheduler YAML conversion to the REST API contract.

- splits YAML file into multiple objects
- converts the YAML object into JSON
- for each JSON:
-- converts the JSON into `proto` struct
-- converts struct into JSON using Protojson
-- sends converted JSON to maestro management API