### PR TITLE
Implement "get operations" action

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -19,4 +19,5 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(getSchedulersCmd)
+	Cmd.AddCommand(getOperationsCmd)
 }

--- a/cmd/get/get_operations.go
+++ b/cmd/get/get_operations.go
@@ -1,0 +1,134 @@
+// maestro-cli
+// https://github.com/topfreegames/maestro-cli
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package get
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/hako/durafmt"
+	"github.com/spf13/cobra"
+	"github.com/topfreegames/maestro-cli/common"
+	"github.com/topfreegames/maestro-cli/extensions"
+	"github.com/topfreegames/maestro-cli/interfaces"
+	v1 "github.com/topfreegames/maestro/pkg/api/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// getOperationsCmd represents the list command
+var getOperationsCmd = &cobra.Command{
+	Use:     "operations",
+	Short:   "Lists all operations from a scheduler",
+	Example: "maestro-cli get operations SCHEDULER_NAME",
+	Args:    validateArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, config, err := common.GetClientAndConfig()
+		if err != nil {
+			return err
+		}
+
+		return NewGetOperations(client, config).run(cmd, args)
+	},
+}
+
+func validateArgs(_ *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return errors.New("missing arg: scheduler name")
+	}
+
+	return nil
+}
+
+type GetOperations struct {
+	client interfaces.Client
+	config *extensions.Config
+}
+
+func NewGetOperations(client interfaces.Client, config *extensions.Config) *GetOperations {
+	return &GetOperations{
+		client: client,
+		config: config,
+	}
+}
+
+func (cs *GetOperations) run(_ *cobra.Command, args []string) error {
+	logger := common.GetLogger()
+	logger.Debug("getting schedulers")
+
+	schedulerName := args[0]
+	url := fmt.Sprintf("%s/schedulers/%s/operations", cs.config.ServerURL, schedulerName)
+	body, status, err := cs.client.Get(url, "")
+	if err != nil {
+		return fmt.Errorf("error on GET request: %w", err)
+	}
+
+	if status != http.StatusOK {
+		return fmt.Errorf("get operations response not ok, status: %s, body: %s", http.StatusText(status), string(body))
+	}
+
+	logger.Sugar().Debugf("success getting scheduler operations: %s", body)
+
+	var operationsLists v1.ListOperationsResponse
+	err = protojson.Unmarshal(body, &operationsLists)
+	if err != nil {
+		return fmt.Errorf("error parsing response body: %w", err)
+	}
+
+	// merge all operations into a single slice
+	// TODO(gabriel.corado): add option to only show operations with specific
+	// status.
+	mergedOperations := append(operationsLists.GetPendingOperations(), operationsLists.GetActiveOperations()...)
+	mergedOperations = append(mergedOperations, operationsLists.GetFinishedOperations()...)
+
+	// TODO(gabriel.corado): add a option to reverse this order.
+	sort.Slice(mergedOperations, func(i, j int) bool {
+		return mergedOperations[i].GetCreatedAt().AsTime().Before(mergedOperations[j].GetCreatedAt().AsTime())
+	})
+
+	if len(mergedOperations) == 0 {
+		fmt.Println("no operations found")
+		return nil
+	}
+
+	cs.printOperationsTable(mergedOperations)
+	return nil
+}
+
+// printOperationsTable receives the operations sorted and print the table to
+// stdout.
+func (cs *GetOperations) printOperationsTable(operations []*v1.Operation) {
+	w := new(tabwriter.Writer)
+
+	// minwidth, tabwidth, padding, padchar, flags
+	w.Init(os.Stdout, 8, 8, 0, '\t', 0)
+
+	defer w.Flush()
+
+	format := "%s\t\t%s\t\t%s\t\t%s\t\n"
+	fmt.Fprintf(w, format, "ID", "NAME", "STATUS", "AGE")
+
+	for _, operation := range operations {
+		age := time.Since(operation.GetCreatedAt().AsTime())
+		prettyAge := durafmt.ParseShort(age).String()
+
+		fmt.Fprintf(
+			w,
+			format,
+			operation.GetId(),
+			strings.ToUpper(operation.GetDefinitionName()),
+			strings.ToUpper(operation.GetStatus()),
+			prettyAge,
+		)
+	}
+}

--- a/cmd/get/get_operations_test.go
+++ b/cmd/get/get_operations_test.go
@@ -1,0 +1,103 @@
+// maestro-cli
+// https://github.com/topfreegames/maestro-cli
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package get
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro-cli/extensions"
+	"github.com/topfreegames/maestro-cli/mocks"
+	v1 "github.com/topfreegames/maestro/pkg/api/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestGetOperationsAction(t *testing.T) {
+	config := &extensions.Config{
+		ServerURL: "http://localhost:8080",
+	}
+
+	t.Run("with success", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		client := mocks.NewMockClient(mockCtrl)
+
+		operations := &v1.ListOperationsResponse{
+			PendingOperations: []*v1.Operation{
+				{
+					Id:             "123",
+					DefinitionName: "remove_rooms",
+					Status:         "pending",
+					CreatedAt:      timestamppb.Now(),
+				},
+			},
+			FinishedOperations: []*v1.Operation{
+				{
+					Id:             "123",
+					DefinitionName: "remove_rooms",
+					Status:         "finished",
+					CreatedAt:      timestamppb.Now(),
+				},
+			},
+		}
+
+		schedulerName := "test"
+		responseBody, err := protojson.Marshal(operations)
+		require.NoError(t, err)
+		client.EXPECT().Get(config.ServerURL+"/schedulers/"+schedulerName+"/operations", gomock.Any()).Return(responseBody, 200, nil)
+
+		err = NewGetOperations(client, config).run(nil, []string{schedulerName})
+		require.NoError(t, err)
+	})
+
+	t.Run("fails when maestro API fails", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		schedulerName := "test"
+		client := mocks.NewMockClient(mockCtrl)
+		client.EXPECT().Get(config.ServerURL+"/schedulers/"+schedulerName+"/operations", gomock.Any()).Return([]byte(""), 404, nil)
+
+		err := NewGetOperations(client, config).run(nil, []string{schedulerName})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "get operations response not ok, status: Not Found")
+	})
+
+	t.Run("fails when bad format response body", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		schedulerName := "test"
+		client := mocks.NewMockClient(mockCtrl)
+		client.EXPECT().Get(config.ServerURL+"/schedulers/"+schedulerName+"/operations", gomock.Any()).Return([]byte(""), 200, nil)
+
+		err := NewGetOperations(client, config).run(nil, []string{schedulerName})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error parsing response body")
+	})
+
+	t.Run("fails when HTTP request faile", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		schedulerName := "test"
+		client := mocks.NewMockClient(mockCtrl)
+		client.EXPECT().Get(config.ServerURL+"/schedulers/"+schedulerName+"/operations", gomock.Any()).Return([]byte(""), 0, errors.New("request failed"))
+
+		err := NewGetOperations(client, config).run(nil, []string{schedulerName})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error on GET request: request failed")
+	})
+}


### PR DESCRIPTION
Adds a new action to list scheduler operation. Here is an example of how it looks like:

```
> maestro-cli get operations <scheduler-name>
ID                                              NAME                    STATUS          AGE
33f76eaf-8cbb-40c6-a49c-adbaca01549e            CREATE_SCHEDULER        PENDING         16 hours
```