### PR TITLE
Cancel operation action

### DIFF
--- a/cmd/add/add_rooms_test.go
+++ b/cmd/add/add_rooms_test.go
@@ -55,7 +55,7 @@ func TestAddRoomsAction(t *testing.T) {
 
 		client := mocks.NewMockClient(mockCtrl)
 
-		client.EXPECT().Post(config.ServerURL+"/schedulers/scheduler/add-rooms", "{\"schedulerName\":\"\", \"amount\":10}").Return([]byte(""), 200, nil)
+		client.EXPECT().Post(config.ServerURL+"/schedulers/scheduler/add-rooms", "{\"schedulerName\":\"\",\"amount\":10}").Return([]byte(""), 200, nil)
 
 		err := NewAddRooms(client, config).run(nil, []string{"scheduler", "10"})
 
@@ -69,7 +69,7 @@ func TestAddRoomsAction(t *testing.T) {
 
 		client := mocks.NewMockClient(mockCtrl)
 
-		client.EXPECT().Post(config.ServerURL+"/schedulers/scheduler/add-rooms", "{\"schedulerName\":\"\", \"amount\":10}").Return([]byte(""), 0, fmt.Errorf("tcp connection failed"))
+		client.EXPECT().Post(config.ServerURL+"/schedulers/scheduler/add-rooms", "{\"schedulerName\":\"\",\"amount\":10}").Return([]byte(""), 0, fmt.Errorf("tcp connection failed"))
 
 		err := NewAddRooms(client, config).run(nil, []string{"scheduler", "10"})
 
@@ -84,7 +84,7 @@ func TestAddRoomsAction(t *testing.T) {
 
 		client := mocks.NewMockClient(mockCtrl)
 
-		client.EXPECT().Post(config.ServerURL+"/schedulers/scheduler/add-rooms", "{\"schedulerName\":\"\", \"amount\":10}").Return([]byte(""), 404, nil)
+		client.EXPECT().Post(config.ServerURL+"/schedulers/scheduler/add-rooms", "{\"schedulerName\":\"\",\"amount\":10}").Return([]byte(""), 404, nil)
 
 		err := NewAddRooms(client, config).run(nil, []string{"scheduler", "10"})
 

--- a/cmd/cancel/cancel.go
+++ b/cmd/cancel/cancel.go
@@ -1,0 +1,23 @@
+// maestro-cli
+// https://github.com/topfreegames/maestro-cli
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package cancel
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Cmd represents the cancel command
+var Cmd = &cobra.Command{
+	Use:   "cancel",
+	Short: "Cancel operation",
+	Long:  `Cancels a resource, to know more, type maestro-cli cancel --help.`,
+}
+
+func init() {
+	Cmd.AddCommand(cancelOperationCmd)
+}

--- a/cmd/cancel/cancel_operation.go
+++ b/cmd/cancel/cancel_operation.go
@@ -1,0 +1,93 @@
+// maestro-cli
+// https://github.com/topfreegames/maestro-cli
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package cancel
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/spf13/cobra"
+	"github.com/topfreegames/maestro-cli/common"
+	"github.com/topfreegames/maestro-cli/extensions"
+	"github.com/topfreegames/maestro-cli/interfaces"
+
+	v1 "github.com/topfreegames/maestro/pkg/api/v1"
+)
+
+// cancelOperationCmd represents the cancel operation command
+var cancelOperationCmd = &cobra.Command{
+	Use:     "operation",
+	Short:   "cancels operation from a given scheduler and ID",
+	Example: "maestro-cli cancel operation <scheduler_name> <id>",
+	Long:    "Given the scheduler name and the operation ID, cancels the found operation in Maestro.",
+	Args:    validateArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, config, err := common.GetClientAndConfig()
+		if err != nil {
+			return err
+		}
+
+		return NewCancelOperation(client, config).run(cmd, args)
+	},
+}
+
+type CancelOperation struct {
+	client interfaces.Client
+	config *extensions.Config
+}
+
+func NewCancelOperation(client interfaces.Client, config *extensions.Config) *CancelOperation {
+	return &CancelOperation{
+		client: client,
+		config: config,
+	}
+}
+
+func (a *CancelOperation) run(_ *cobra.Command, args []string) error {
+
+	logger := common.GetLogger()
+	schedulerName := args[0]
+	operationID := args[1]
+
+	request := v1.CancelOperationRequest{}
+	serializedRequest, err := protojson.Marshal(&request)
+	if err != nil {
+		return fmt.Errorf("error parsing request to json: %w", err)
+	}
+
+	logger.Sugar().Debugf("cancel operation %s from scheduler %s", schedulerName, operationID)
+
+	url := fmt.Sprintf("%s/schedulers/%s/operations/%s/cancel", a.config.ServerURL, schedulerName, operationID)
+	body, status, err := a.client.Post(url, string(serializedRequest))
+	if err != nil {
+		return fmt.Errorf("error on post request: %w", err)
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("cancel operation response not ok, status: %s, body: %s", http.StatusText(status), string(body))
+	}
+	var response v1.CancelOperationResponse
+	err = protojson.Unmarshal(body, &response)
+	if err != nil {
+		return fmt.Errorf("error deserializing cancel operation response, details: %w", err)
+	}
+
+	logger.Info("cancel operation request successfully sent")
+
+	return nil
+}
+
+func validateArgs(_ *cobra.Command, args []string) error {
+	if len(args) < 2 {
+		return errors.New("missing args: scheduler name or/and operation ID")
+	}
+
+	return nil
+}

--- a/cmd/cancel/cancel_operation_test.go
+++ b/cmd/cancel/cancel_operation_test.go
@@ -1,0 +1,119 @@
+// maestro-cli
+// https://github.com/topfreegames/maestro-cli
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package cancel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/maestro-cli/extensions"
+	"github.com/topfreegames/maestro-cli/mocks"
+)
+
+func TestCancelOperationAction(t *testing.T) {
+
+	config := &extensions.Config{
+		ServerURL: "http://localhost:8080",
+	}
+
+	t.Run("fails when not enough args", func(t *testing.T) {
+		err := validateArgs(nil, []string{})
+
+		require.Error(t, err)
+		require.Equal(t, "missing args: scheduler name or/and operation ID", err.Error())
+
+		err = validateArgs(nil, []string{"scheduler"})
+
+		require.Error(t, err)
+		require.Equal(t, "missing args: scheduler name or/and operation ID", err.Error())
+	})
+
+	t.Run("validate args with success", func(t *testing.T) {
+		err := validateArgs(nil, []string{"scheduler", uuid.NewString()})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("with success", func(t *testing.T) {
+
+		schedulerName := "scheduler-name-1"
+		operationID := "operation-id-1"
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		client := mocks.NewMockClient(mockCtrl)
+
+		url := fmt.Sprintf("%s/schedulers/%s/operations/%s/cancel", config.ServerURL, schedulerName, operationID)
+		client.EXPECT().Post(url, gomock.Any()).Return([]byte("{}"), 200, nil)
+
+		err := NewCancelOperation(client, config).run(nil, []string{schedulerName, operationID})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("fails when response deserialization fails", func(t *testing.T) {
+
+		schedulerName := "scheduler-name-1"
+		operationID := "operation-id-1"
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		client := mocks.NewMockClient(mockCtrl)
+
+		url := fmt.Sprintf("%s/schedulers/%s/operations/%s/cancel", config.ServerURL, schedulerName, operationID)
+		client.EXPECT().Post(url, gomock.Any()).Return([]byte(""), 200, nil)
+
+		err := NewCancelOperation(client, config).run(nil, []string{schedulerName, operationID})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error deserializing cancel operation response")
+	})
+
+	t.Run("fails when HTTP request fails", func(t *testing.T) {
+
+		schedulerName := "scheduler-name-1"
+		operationID := "operation-id-1"
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		client := mocks.NewMockClient(mockCtrl)
+
+		url := fmt.Sprintf("%s/schedulers/%s/operations/%s/cancel", config.ServerURL, schedulerName, operationID)
+		client.EXPECT().Post(url, gomock.Any()).Return([]byte(""), 0, fmt.Errorf("tcp connection failed"))
+
+		err := NewCancelOperation(client, config).run(nil, []string{schedulerName, operationID})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error on post request: tcp connection failed")
+	})
+
+	t.Run("fails when maestro API fails", func(t *testing.T) {
+
+		schedulerName := "scheduler-name-1"
+		operationID := "operation-id-1"
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		client := mocks.NewMockClient(mockCtrl)
+
+		url := fmt.Sprintf("%s/schedulers/%s/operations/%s/cancel", config.ServerURL, schedulerName, operationID)
+		client.EXPECT().Post(url, gomock.Any()).Return([]byte(""), 400, nil)
+
+		err := NewCancelOperation(client, config).run(nil, []string{schedulerName, operationID})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cancel operation response not ok, status: Bad Request, body: ")
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/topfreegames/maestro-cli/cmd/add"
+	"github.com/topfreegames/maestro-cli/cmd/cancel"
 	"github.com/topfreegames/maestro-cli/cmd/create"
 	"github.com/topfreegames/maestro-cli/cmd/get"
 	initPkg "github.com/topfreegames/maestro-cli/cmd/init"
@@ -47,6 +48,7 @@ func init() {
 	RootCmd.AddCommand(remove.Cmd)
 	RootCmd.AddCommand(initPkg.Cmd)
 	RootCmd.AddCommand(create.Cmd)
+	RootCmd.AddCommand(cancel.Cmd)
 	RootCmd.AddCommand(version.Cmd)
 	RootCmd.AddCommand(get.Cmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,14 @@ go 1.16
 require (
 	github.com/golang/mock v1.5.0
 	github.com/golangci/golangci-lint v1.41.1
+	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/onsi/ginkgo v1.16.1
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
-	github.com/topfreegames/maestro v1.0.1-0.20210908185840-76d2610cf3e6
+	github.com/topfreegames/maestro v1.0.1-0.20210928143715-3418be0ed346
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 	go.uber.org/zap v1.18.1
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,8 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.5.0/go.mod h1:ngWDr9Qvq3yZA10YrxfyGELY/AFWGVpy9c1LTRi1EoU=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -956,8 +958,8 @@ github.com/tomarrell/wrapcheck/v2 v2.1.0/go.mod h1:crK5eI4RGSUrb9duDTQ5GqcukbKZv
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/tommy-muehle/go-mnd/v2 v2.4.0 h1:1t0f8Uiaq+fqKteUR4N9Umr6E99R+lDnLnq7PwX2PPE=
 github.com/tommy-muehle/go-mnd/v2 v2.4.0/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
-github.com/topfreegames/maestro v1.0.1-0.20210908185840-76d2610cf3e6 h1:qqBj0Xq0aDEV8bTyeQ0KTplTgGbQq32tJDyioC17u4E=
-github.com/topfreegames/maestro v1.0.1-0.20210908185840-76d2610cf3e6/go.mod h1:K4d61XPO+FUBT+M6P2U1XFNsz7CFRjdI94Lohicx37I=
+github.com/topfreegames/maestro v1.0.1-0.20210928143715-3418be0ed346 h1:wF3pMW5DPtg5oesSVRYv38j3mEsDq8AoZvop4GlCV2k=
+github.com/topfreegames/maestro v1.0.1-0.20210928143715-3418be0ed346/go.mod h1:K4d61XPO+FUBT+M6P2U1XFNsz7CFRjdI94Lohicx37I=
 github.com/twitchtv/twirp v8.1.0+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=


### PR DESCRIPTION
## What?

This PR aims to add the action of operation cancelation. Following:

```
$ maestro cancel operation <scheduler_name> <operation_id>
```

Basically, it calls the `POST /schedulers/:scheduler_name/operations/:id/cancel` that enqueues a request to the worker to cancel the operation.