### PR TITLE
feat: rooms on maestro-cli shows prop LastPingMetadata

### DIFF
--- a/cmd/rooms.go
+++ b/cmd/rooms.go
@@ -54,6 +54,7 @@ type gameRoom struct {
 	Status           string
 	CreatedAt        string
 	LastPingAt       string
+	LastPingMetadata map[string]interface{}
 }
 
 // roomsCmd represents the rooms command
@@ -121,8 +122,8 @@ func printRoomsTable(rooms []gameRoom) {
 
 	defer w.Flush()
 
-	format := "%s\t\t%s\t\t%s\t\t%s\t\t%s\t\t%s\t\n"
-	fmt.Fprintf(w, format, "SCHEDULER_NAME", "SCHEDULER_VERSION", "ROOM_ID", "STATUS", "ROOM_AGE", "LAST_PING_AGE")
+	format := "%s\t\t%s\t\t%s\t\t%s\t\t%s\t\t%s\t\t%s\t\n"
+	fmt.Fprintf(w, format, "SCHEDULER_NAME", "SCHEDULER_VERSION", "ROOM_ID", "STATUS", "ROOM_AGE", "LAST_PING_AGE", "LAST_PING_METADATA")
 
 	for _, room := range rooms {
 
@@ -133,6 +134,7 @@ func printRoomsTable(rooms []gameRoom) {
 		if lastPingAt.Before(createdAt) || lastPingAt.Equal(createdAt) {
 			pingPrettyAge = "no ping sent yet"
 		}
+		prettyLastPingMetadata, _ := json.Marshal(room.LastPingMetadata)
 
 		fmt.Fprintf(
 			w,
@@ -143,6 +145,7 @@ func printRoomsTable(rooms []gameRoom) {
 			room.Status,
 			prettyAge,
 			pingPrettyAge,
+			string(prettyLastPingMetadata),
 		)
 	}
 }


### PR DESCRIPTION
### What?
   Changes on struct gameRoom. Added new property LastPingMetadata to both **room** and **rooms** commands.
### Why?
   Maestro-API now have the value LastPingMetadata for rooms details. The cli now prints these values too.
### How?
- added **LastPingMetadata** of type **map[string]interface{}**
- Changes on function **printRoomsTable** 