### PR TITLE
add lease information on get operations command

### DIFF
--- a/cmd/get/get_operations.go
+++ b/cmd/get/get_operations.go
@@ -125,7 +125,7 @@ func (cs *GetOperations) printOperationsTable(operations []*v1.Operation) {
 
 		leaseTtl := "-"
 		leaseExpired := "-"
-		if operation.Lease.GetTtl() != "" {
+		if operation.Lease != nil {
 			leaseTtl = operation.Lease.GetTtl()
 			parsedLeaseTtl, err := time.Parse(time.RFC3339, operation.Lease.GetTtl())
 			if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/topfreegames/maestro-cli
 go 1.16
 
 require (
-	github.com/golang/mock v1.5.0
+	github.com/golang/mock v1.6.0
 	github.com/golangci/golangci-lint v1.41.1
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
@@ -12,7 +12,7 @@ require (
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
-	github.com/topfreegames/maestro v1.0.1-0.20211124145428-60a98f212c49
+	github.com/topfreegames/maestro v1.0.1-0.20220107213135-829d51ff5769
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 	go.uber.org/zap v1.18.1
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -348,8 +348,9 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
-github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -959,8 +960,8 @@ github.com/tomarrell/wrapcheck/v2 v2.1.0/go.mod h1:crK5eI4RGSUrb9duDTQ5GqcukbKZv
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/tommy-muehle/go-mnd/v2 v2.4.0 h1:1t0f8Uiaq+fqKteUR4N9Umr6E99R+lDnLnq7PwX2PPE=
 github.com/tommy-muehle/go-mnd/v2 v2.4.0/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
-github.com/topfreegames/maestro v1.0.1-0.20211124145428-60a98f212c49 h1:Fqb25SM8WykgFpFl507zaAHOgmpYbcjmolR61Y/F+8o=
-github.com/topfreegames/maestro v1.0.1-0.20211124145428-60a98f212c49/go.mod h1:M6ogIFwu3lNpDhddaqRpELmgziaR8rNXdNSEbjNcpmc=
+github.com/topfreegames/maestro v1.0.1-0.20220107213135-829d51ff5769 h1:fjgOMoENkYE7ZLsUgVhv8bogE3dB56yacb6LhqP6JLI=
+github.com/topfreegames/maestro v1.0.1-0.20220107213135-829d51ff5769/go.mod h1:CBz8BNd69yTO1bsgacrxa9mJ9c8sDDRWrpEroSrOI7o=
 github.com/twitchtv/twirp v8.1.0+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -1409,6 +1410,7 @@ golang.org/x/tools v0.0.0-20210104081019-d8d6ddbec6ee/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=


### PR DESCRIPTION
### What?
On method get operations, add Operation Lease information to be printed.
### Why?
After the implementation of Operation Leases, we have a crucial info to troubleshooting maestro. We want this info to be together with operations so we can understand if the operation is stuck or not.
### How?
If the operation has the lease object, we use the ttl to print the information (when the lease will expire) and compare it to now to see if the lease has already expired.