### PR TITLE
Add filters on get schedulers command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SOURCES := $(shell \
 
 build:
 	@mkdir -p bin
-	@go build -o ./bin/maestro main.go
+	@go build -o ./bin/maestro-cli main.go
 
 test: unit test-coverage-func
 	

--- a/cmd/get/get_schedulers_test.go
+++ b/cmd/get/get_schedulers_test.go
@@ -25,7 +25,7 @@ func TestGetSchedulersAction(t *testing.T) {
 		ServerURL: "http://localhost:8080",
 	}
 
-	t.Run("with success", func(t *testing.T) {
+	t.Run("when there is no parameter it should return with success", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -47,7 +47,38 @@ func TestGetSchedulersAction(t *testing.T) {
 
 		client.EXPECT().Get(config.ServerURL+"/schedulers", gomock.Any()).Return(responseBody, 200, nil)
 
-		err := NewGetSchedulers(client, config).run(nil, []string{})
+		parameters := &GetSchedulersParameters{}
+
+		err := NewGetSchedulers(client, config, parameters).run(nil, []string{})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("when there are parameters it should return with success", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		client := mocks.NewMockClient(mockCtrl)
+
+		schedulers := &v1.ListSchedulersResponse{
+			Schedulers: []*v1.SchedulerWithoutSpec{
+				{
+					Name:      "scheduler-test-1",
+					Game:      "the-game",
+					Version:   "1.0.0",
+					State:     "creating",
+					CreatedAt: timestamppb.Now(),
+				},
+			},
+		}
+
+		responseBody, _ := protojson.Marshal(schedulers)
+
+		client.EXPECT().Get(config.ServerURL+"/schedulers?name=some name", gomock.Any()).Return(responseBody, 200, nil)
+
+		parameters := &GetSchedulersParameters{Name: "some name"}
+
+		err := NewGetSchedulers(client, config, parameters).run(nil, []string{})
 
 		require.NoError(t, err)
 	})
@@ -59,7 +90,9 @@ func TestGetSchedulersAction(t *testing.T) {
 		client := mocks.NewMockClient(mockCtrl)
 		client.EXPECT().Get(config.ServerURL+"/schedulers", gomock.Any()).Return([]byte(""), 404, nil)
 
-		err := NewGetSchedulers(client, config).run(nil, []string{})
+		parameters := &GetSchedulersParameters{}
+
+		err := NewGetSchedulers(client, config, parameters).run(nil, []string{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "get schedulers response not ok, status: Not Found")
@@ -72,7 +105,9 @@ func TestGetSchedulersAction(t *testing.T) {
 		client := mocks.NewMockClient(mockCtrl)
 		client.EXPECT().Get(config.ServerURL+"/schedulers", gomock.Any()).Return([]byte(""), 200, nil)
 
-		err := NewGetSchedulers(client, config).run(nil, []string{})
+		parameters := &GetSchedulersParameters{}
+
+		err := NewGetSchedulers(client, config, parameters).run(nil, []string{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error parsing response body")
@@ -85,9 +120,62 @@ func TestGetSchedulersAction(t *testing.T) {
 		client := mocks.NewMockClient(mockCtrl)
 		client.EXPECT().Get(config.ServerURL+"/schedulers", gomock.Any()).Return([]byte(""), 0, errors.New("request failed"))
 
-		err := NewGetSchedulers(client, config).run(nil, []string{})
+		parameters := &GetSchedulersParameters{}
+
+		err := NewGetSchedulers(client, config, parameters).run(nil, []string{})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error on GET request: request failed")
 	})
+}
+
+func TestBuildURLParameters(t *testing.T) {
+	type input struct {
+		Name    string
+		Game    string
+		Version string
+	}
+
+	testCases := []struct {
+		Title          string
+		Input          input
+		ExpectedReturn string
+	}{
+		{
+			Title:          "when there is only name",
+			Input:          input{Name: "some-name"},
+			ExpectedReturn: "?name=some-name",
+		}, {
+			Title:          "when there is only game",
+			Input:          input{Game: "some-game"},
+			ExpectedReturn: "?game=some-game",
+		}, {
+			Title:          "when there is only version",
+			Input:          input{Version: "some-version"},
+			ExpectedReturn: "?version=some-version",
+		}, {
+			Title:          "when there are name and game",
+			Input:          input{Name: "some-name", Game: "some-game"},
+			ExpectedReturn: "?name=some-name&game=some-game",
+		}, {
+			Title:          "when there are name and version",
+			Input:          input{Name: "some-name", Version: "some-version"},
+			ExpectedReturn: "?name=some-name&version=some-version",
+		}, {
+			Title:          "when there are game and version",
+			Input:          input{Game: "some-game", Version: "some-version"},
+			ExpectedReturn: "?game=some-game&version=some-version",
+		}, {
+			Title:          "when there are all parameters",
+			Input:          input{Game: "some-game", Version: "some-version"},
+			ExpectedReturn: "?game=some-game&version=some-version",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Title, func(t *testing.T) {
+			returnedParameters := buildURLParameters(testCase.Input.Name, testCase.Input.Game, testCase.Input.Version)
+			require.Equal(t, testCase.ExpectedReturn, returnedParameters)
+		})
+	}
 }


### PR DESCRIPTION
### Why
To enable client pass filters to `get schedulers`.

### What
Currently, the `get schedulers` command doesn't accept filters by `name`, `game`, and `version`.

### How
This PR proposes to add the flags `name` (`n`), `game` (`g`), `version` (`t`) that are sent as query parameters in the `GET /schedulers`.