### PR TITLE
Adds Input and Execution History to operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ bin
 .vscode
 __debug_bin
 .editorconfig
+
+# Other
+.idea/

--- a/cmd/create/scheduler/create_scheduler_test.go
+++ b/cmd/create/scheduler/create_scheduler_test.go
@@ -32,37 +32,40 @@ func TestCreateSchedulerAction(t *testing.T) {
 
 	t.Run("with success", func(t *testing.T) {
 		expectedStructuredBody := v1.CreateSchedulerRequest{
-			Name:                   "scheduler-name-1",
-			Game:                   "game-name",
-			TerminationGracePeriod: 100,
-			PortRange: &v1.PortRange{
-				Start: 1,
-				End:   1000,
+			Name:     "scheduler-test",
+			Game:     "game-test",
+			MaxSurge: "10%",
+			Spec: &v1.Spec{
+				TerminationGracePeriod: 15,
+				Containers: []*v1.Container{
+					{
+						Name:            "example",
+						Image:           "alpine:3.15.0",
+						Command:         []string{"sh", "-c", "while true; do sleep 1; done"},
+						ImagePullPolicy: "Always",
+						Environment:     []*v1.ContainerEnvironment{},
+						Requests: &v1.ContainerResources{
+							Memory: "20Mi",
+							Cpu:    "10m",
+						},
+						Limits: &v1.ContainerResources{
+							Memory: "20Mi",
+							Cpu:    "10m",
+						},
+						Ports: []*v1.ContainerPort{
+							{
+								Name:     "default",
+								Protocol: "tcp",
+								Port:     80,
+							},
+						},
+					},
+				},
 			},
-			Containers: []*v1.Container{{
-				Name:            "game-room-container-name",
-				Image:           "game-room-container-image",
-				ImagePullPolicy: "IfNotPresent",
-				Command:         []string{"./run"},
-				Environment: []*v1.ContainerEnvironment{{
-					Name:  "env-var-name",
-					Value: "env-var-value",
-				}},
-				Requests: &v1.ContainerResources{
-					Memory: "100mi",
-					Cpu:    "100m",
-				},
-				Limits: &v1.ContainerResources{
-					Memory: "200mi",
-					Cpu:    "200m",
-				},
-				Ports: []*v1.ContainerPort{{
-					Name:     "container-port-name",
-					Protocol: "https",
-					Port:     12345,
-					HostPort: 54321,
-				}},
-			}},
+			PortRange: &v1.PortRange{
+				Start: 80,
+				End:   8000,
+			},
 		}
 
 		expectedStringBody, _ := protojson.Marshal(&expectedStructuredBody)

--- a/cmd/create/scheduler/fixtures/scheduler-config.yaml
+++ b/cmd/create/scheduler/fixtures/scheduler-config.yaml
@@ -1,27 +1,46 @@
 ---
 name: scheduler-name-1
-game: game-name
-termination_grace_period: 100
+game: game-test
 portRange:
   start: 1
   end: 1000
-containers:
-- name: game-room-container-name
-  image: game-room-container-image
-  image_pull_policy: IfNotPresent
-  command:
-  - "./run"
-  environment:
-  - name: env-var-name
-    value: env-var-value
-  requests:
-    memory: 100mi
-    cpu: 100m
-  limits:
-    memory: 200mi
-    cpu: 200m
-  ports:
-  - name: container-port-name
-    protocol: https
-    port: 12345
-    host_port: 54321
+maxSurge: 20%
+spec:
+  version: v1.0.0
+  terminationGracePeriod: '100'
+  containers:
+    - name: alpine
+      image: alpine
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - '-c'
+        - >-
+          apk add curl && while true; do curl --request POST
+          rooms-api.maestro-next.svc.cluster.local:8090/scheduler/$MAESTRO_SCHEDULER_NAME/rooms/$MAESTRO_ROOM_ID/ping
+          --data-raw '{"status": "ready","timestamp": "12312312313"}' && sleep
+          1; done
+      environment:
+        - name: env-var-name
+          value: env-var-value
+      requests:
+        memory: 20Mi
+        cpu: 100m
+      limits:
+        memory: 200Mi
+        cpu: 200m
+      ports:
+        - name: port-name
+          protocol: tcp
+          port: 12345
+          hostPort: 412
+  toleration: ''
+  affinity: ''
+forwarders:
+  - name: test
+    enable: true
+    type: gRPC
+    address: 'www.test.com'
+    options:
+      timeout: '1000'
+      metadata: {}

--- a/cmd/create/scheduler_version/fixtures/scheduler-config.yaml
+++ b/cmd/create/scheduler_version/fixtures/scheduler-config.yaml
@@ -1,27 +1,46 @@
 ---
 name: scheduler-name-1
-game: game-name
-termination_grace_period: 100
+game: game-test
 portRange:
   start: 1
   end: 1000
-containers:
-- name: game-room-container-name
-  image: game-room-container-image
-  image_pull_policy: IfNotPresent
-  command:
-  - "./run"
-  environment:
-  - name: env-var-name
-    value: env-var-value
-  requests:
-    memory: 100mi
-    cpu: 100m
-  limits:
-    memory: 200mi
-    cpu: 200m
-  ports:
-  - name: container-port-name
-    protocol: https
-    port: 12345
-    host_port: 54321
+maxSurge: 20%
+spec:
+  version: v1.0.0
+  terminationGracePeriod: '100'
+  containers:
+    - name: alpine
+      image: alpine
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - '-c'
+        - >-
+          apk add curl && while true; do curl --request POST
+          rooms-api.maestro-next.svc.cluster.local:8090/scheduler/$MAESTRO_SCHEDULER_NAME/rooms/$MAESTRO_ROOM_ID/ping
+          --data-raw '{"status": "ready","timestamp": "12312312313"}' && sleep
+          1; done
+      environment:
+        - name: env-var-name
+          value: env-var-value
+      requests:
+        memory: 20Mi
+        cpu: 100m
+      limits:
+        memory: 200Mi
+        cpu: 200m
+      ports:
+        - name: port-name
+          protocol: tcp
+          port: 12345
+          hostPort: 412
+  toleration: ''
+  affinity: ''
+forwarders:
+  - name: test
+    enable: true
+    type: gRPC
+    address: 'www.test.com'
+    options:
+      timeout: '1000'
+      metadata: {}

--- a/cmd/get/get_schedulers_info.go
+++ b/cmd/get/get_schedulers_info.go
@@ -88,6 +88,6 @@ func (s *GetSchedulersInfo) printSchedulersTable(schedulers []*v1.SchedulerInfo)
 	fmt.Fprintf(w, format, "SCHEDULER", "GAME", "STATE", "ROOM_SREADY", "ROOMS_OCCUPIED", "ROOMS_CREATING", "ROOMS_TERMINATING")
 
 	for _, scheduler := range schedulers {
-		fmt.Fprintf(w, format, scheduler.GetName(), scheduler.GetName(), scheduler.GetState(), strconv.Itoa(int(scheduler.GetRoomsReady())), strconv.Itoa(int(scheduler.GetRoomsOccupied())), strconv.Itoa(int(scheduler.GetRoomsCreating())), strconv.Itoa(int(scheduler.GetRoomsTerminating())))
+		fmt.Fprintf(w, format, scheduler.GetName(), scheduler.GetName(), scheduler.GetState(), strconv.Itoa(int(scheduler.GetRoomsReady())), strconv.Itoa(int(scheduler.GetRoomsOccupied())), strconv.Itoa(int(scheduler.GetRoomsPending())), strconv.Itoa(int(scheduler.GetRoomsTerminating())))
 	}
 }

--- a/cmd/get/get_schedulers_info_test.go
+++ b/cmd/get/get_schedulers_info_test.go
@@ -29,7 +29,7 @@ func TestGetSchedulersInfoAction(t *testing.T) {
 					State:            "creating",
 					RoomsReady:       10,
 					RoomsTerminating: 2,
-					RoomsCreating:    5,
+					RoomsPending:     5,
 					RoomsOccupied:    20,
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/afero v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
-	github.com/topfreegames/maestro v1.0.1-0.20220222225259-dc2b33ba8cc3
+	github.com/topfreegames/maestro v1.0.1-0.20220317172050-8891335a8360
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/zap v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -1079,10 +1079,10 @@ github.com/tomarrell/wrapcheck/v2 v2.1.0/go.mod h1:crK5eI4RGSUrb9duDTQ5GqcukbKZv
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/tommy-muehle/go-mnd/v2 v2.4.0 h1:1t0f8Uiaq+fqKteUR4N9Umr6E99R+lDnLnq7PwX2PPE=
 github.com/tommy-muehle/go-mnd/v2 v2.4.0/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
-github.com/topfreegames/maestro v1.0.1-0.20220211163950-d204be8492c2 h1:WhzLPsdGJq7kVlAZ/WFdUo9eV/0o9ZsEgMgkJtEZy04=
-github.com/topfreegames/maestro v1.0.1-0.20220211163950-d204be8492c2/go.mod h1:FAkRtxy4RkZMC3e6p/GAspn+2gOi3RsyzhbBn1hbRYM=
 github.com/topfreegames/maestro v1.0.1-0.20220222225259-dc2b33ba8cc3 h1:tc8IBGSu+6rtZUZlhOh/QC95+PSLy5kehDAweoHAgtY=
 github.com/topfreegames/maestro v1.0.1-0.20220222225259-dc2b33ba8cc3/go.mod h1:FAkRtxy4RkZMC3e6p/GAspn+2gOi3RsyzhbBn1hbRYM=
+github.com/topfreegames/maestro v1.0.1-0.20220317172050-8891335a8360 h1:OXF1umsCWW/Uzit9yLYKXNqEQBv2zH+26DJXG5jaoG8=
+github.com/topfreegames/maestro v1.0.1-0.20220317172050-8891335a8360/go.mod h1:1m+QA50Bg9NV3zhL1fVWgAGXFTbKAkguO+ps4K/oeTs=
 github.com/topfreegames/protos v1.8.0 h1:y18JHIwcXfGfjRbXt043dKSvz8ZNIqaKKyDrF8NqaHM=
 github.com/topfreegames/protos v1.8.0/go.mod h1:qHAf/WxOHNdgRC7/8DGxe4rE+7HdPuzFCuTXT/gxDWk=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
### What?
Adds options to `get operations` on fetching `input` and `exec history` data.
### Why?
To better troubleshoot what's happening to a scheduler, we want more information about the operations. Maestro API gives us that information, but we have to add this information to CLI too.

### Non-related refactoring
In order to upgrade the version used by maestro and still pass tests and lint, I had to fix the tests of Create Scheduler and Create New Scheduler version.