### PR TITLE
Remove from get operations input and execution history

### DIFF
--- a/cmd/get/get_operations_test.go
+++ b/cmd/get/get_operations_test.go
@@ -25,7 +25,6 @@ func TestGetOperationsAction(t *testing.T) {
 	config := &extensions.Config{
 		ServerURL: "http://localhost:8080",
 	}
-	params := &GetOperationsParameters{Input: true, ExecutionHistory: true}
 
 	t.Run("with success", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
@@ -44,14 +43,12 @@ func TestGetOperationsAction(t *testing.T) {
 			},
 			FinishedOperations: []*v1.Operation{
 				{
-					Id:               "123",
-					Status:           "finished",
-					DefinitionName:   "remove_rooms",
-					Lease:            &v1.Lease{Ttl: "2022-01-01"},
-					SchedulerName:    "Name",
-					CreatedAt:        timestamppb.Now(),
-					Input:            nil,
-					ExecutionHistory: nil,
+					Id:             "123",
+					Status:         "finished",
+					DefinitionName: "remove_rooms",
+					Lease:          &v1.Lease{Ttl: "2022-01-01"},
+					SchedulerName:  "Name",
+					CreatedAt:      timestamppb.Now(),
 				},
 			},
 		}
@@ -61,7 +58,7 @@ func TestGetOperationsAction(t *testing.T) {
 		require.NoError(t, err)
 		client.EXPECT().Get(config.ServerURL+"/schedulers/"+schedulerName+"/operations", gomock.Any()).Return(responseBody, 200, nil)
 
-		err = NewGetOperations(client, config, params).run(nil, []string{schedulerName})
+		err = NewGetOperations(client, config).run(nil, []string{schedulerName})
 		require.NoError(t, err)
 	})
 
@@ -82,7 +79,7 @@ func TestGetOperationsAction(t *testing.T) {
 		require.NoError(t, err)
 		client.EXPECT().Get(config.ServerURL+"/schedulers/"+schedulerName+"/operations", gomock.Any()).Return(responseBody, 200, nil)
 
-		err = NewGetOperations(client, config, params).run(nil, []string{schedulerName})
+		err = NewGetOperations(client, config).run(nil, []string{schedulerName})
 		require.NoError(t, err)
 	})
 
@@ -94,7 +91,7 @@ func TestGetOperationsAction(t *testing.T) {
 		client := mocks.NewMockClient(mockCtrl)
 		client.EXPECT().Get(config.ServerURL+"/schedulers/"+schedulerName+"/operations", gomock.Any()).Return([]byte(""), 404, nil)
 
-		err := NewGetOperations(client, config, params).run(nil, []string{schedulerName})
+		err := NewGetOperations(client, config).run(nil, []string{schedulerName})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "get operations response not ok, status: Not Found")
@@ -108,7 +105,7 @@ func TestGetOperationsAction(t *testing.T) {
 		client := mocks.NewMockClient(mockCtrl)
 		client.EXPECT().Get(config.ServerURL+"/schedulers/"+schedulerName+"/operations", gomock.Any()).Return([]byte(""), 200, nil)
 
-		err := NewGetOperations(client, config, params).run(nil, []string{schedulerName})
+		err := NewGetOperations(client, config).run(nil, []string{schedulerName})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error parsing response body")
@@ -122,7 +119,7 @@ func TestGetOperationsAction(t *testing.T) {
 		client := mocks.NewMockClient(mockCtrl)
 		client.EXPECT().Get(config.ServerURL+"/schedulers/"+schedulerName+"/operations", gomock.Any()).Return([]byte(""), 0, errors.New("request failed"))
 
-		err := NewGetOperations(client, config, params).run(nil, []string{schedulerName})
+		err := NewGetOperations(client, config).run(nil, []string{schedulerName})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error on GET request: request failed")
@@ -167,7 +164,7 @@ func TestGetOperationsAction(t *testing.T) {
 		require.NoError(t, err)
 		client.EXPECT().Get(config.ServerURL+"/schedulers/"+schedulerName+"/operations", gomock.Any()).Return(responseBody, 200, nil)
 
-		err = NewGetOperations(client, config, params).run(nil, []string{schedulerName})
+		err = NewGetOperations(client, config).run(nil, []string{schedulerName})
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
### Why
Currently command `get operations` accepts two parameters `i` to `Input` and `x` to `ExecutionHistory`. But it is being deprecated by the original maestro API.

### What
- Remove `input` and `executionHistory` from `get operations` command